### PR TITLE
DataStoreEntityJSONEncoderの型判定の修正

### DIFF
--- a/datastore_viewer/presentation/ui/api/encoder.py
+++ b/datastore_viewer/presentation/ui/api/encoder.py
@@ -9,12 +9,12 @@ class DataStoreEntityJSONEncoder:
         # TODO: Handling Geographical points, Array, Object
         if isinstance(prop, str):
             return "string"
+        elif isinstance(prop, bool):
+            return "boolean"
         elif isinstance(prop, int):
             return "integer"
         elif isinstance(prop, float):
             return "float"
-        elif isinstance(prop, bool):
-            return "boolean"
         elif isinstance(prop, datetime.datetime):
             return "timestamp"
         elif isinstance(prop, datastore.Key):

--- a/webapp/src/domain/Property/BooleanProperty.ts
+++ b/webapp/src/domain/Property/BooleanProperty.ts
@@ -4,7 +4,7 @@ export default class BooleanProperty implements Property {
     index: boolean;
 
     constructor(value: string, name: string, index: boolean) {
-        this.value = value.toLowerCase() === 'true';
+        this.value = value === 'true';
         this.name = name;
         this.index = index;
     }


### PR DESCRIPTION
* `isinstance(hoge, int)` は bool でも True を返す ( bool が int のサブクラスであるため)
* 逆に `isinstance(hoge, bool)` は int だと False となるため、型の判定を bool → int の順に変更