### PR TITLE
ページ番号が少数や負の数にならないようにする

### DIFF
--- a/webapp/public/index.html
+++ b/webapp/public/index.html
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>Datastore Viewer</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/webapp/src/presentation/App.tsx
+++ b/webapp/src/presentation/App.tsx
@@ -30,10 +30,18 @@ interface Props {
     qs: ParsedQuery;
 }
 
+const pageValidator = function(page: number): number {
+    if(!Number.isInteger(page) || page < 0) {
+        return 0;
+    }else {
+        return page;
+    }
+};
+
 const App = (props: Props) => {
     const [projectName, setProjectName] = React.useState(props.qs.projectName ? props.qs.projectName : '');
     const [kind, setKind] = React.useState(props.qs.kind ? props.qs.kind : '');
-    const [page, setPage] = React.useState(props.qs.page ? Number(props.qs.page) : 0);
+    const [page, setPage] = React.useState(props.qs.page ? pageValidator(Number(props.qs.page)) : 0);
     const [lang, setLang] = React.useState<string>('en');
     let history = useHistory();
 

--- a/webapp/src/presentation/views/EntityList/EntityList.tsx
+++ b/webapp/src/presentation/views/EntityList/EntityList.tsx
@@ -32,7 +32,7 @@ export default function EntityList(props: Props) {
         if(kindObj){
             getEntityList(props.projectName, kindObj.kind, page, rowsPerPage)
                 .then( entityCollection => {
-                    const maxPage = entityCollection.totalCount / rowsPerPage - 1;
+                    const maxPage = Math.floor(entityCollection.totalCount / rowsPerPage);
                     if(maxPage < page) setPage(maxPage);
                     console.log('updateEntities', entityCollection);
                     setEntities(entityCollection);


### PR DESCRIPTION
* ページタイトルを `Datastore Viewer` に変更
* maxPage の計算結果が少数にならないように `Math.floor()`を適用
* クエリで渡されたページ番号が負の数や少数の場合は0を返すようにvalidatorを追加