### PR TITLE
EntityEditの不具合修正

### DIFF
--- a/webapp/src/presentation/App.tsx
+++ b/webapp/src/presentation/App.tsx
@@ -69,7 +69,7 @@ const App = (props: Props) => {
         <div className="App">
             <Header setProjectName={setProjectName} projectName={projectName} setLang={setLang} lang={lang}/>
             <Route exact path="/datastore_viewer" render={() => <EntityList setKind={setKind} kind={kind} setPage={setPage} page={page} projectName={projectName} lang={lang}/>} />
-            <Route path="/datastore_viewer/edit/update/:kind/:urlSafeKey" render={() => <EntityEdit projectName={projectName} lang={lang}/>} />
+            <Route path="/datastore_viewer/edit/update/:projectName/:kind/:urlSafeKey" render={() => <EntityEdit lang={lang}/>} />
             <Route path="/datastore_viewer/edit/new" render={() => <NewEntityEdit lang={lang}/>} />
         </div>
     );

--- a/webapp/src/presentation/App.tsx
+++ b/webapp/src/presentation/App.tsx
@@ -31,7 +31,7 @@ const App = (props: Props) => {
     const [kind, setKind] = React.useState(props.qs.kind ? props.qs.kind : '');
     const [page, setPage] = React.useState(props.qs.page ? pageValidator(Number(props.qs.page)) : 0);
     const [lang, setLang] = React.useState<string>(cookies['lang'] ? cookies['lang'] : 'en');
-    let history = useHistory();
+    const history = useHistory();
 
     i18n.use(initReactI18next).init({
         resources: {
@@ -52,17 +52,21 @@ const App = (props: Props) => {
     }, [lang]);
 
     React.useEffect(() => {
-        let queryPath = '/datastore_viewer/?';
-        if(projectName) queryPath += `projectName=${projectName}`;
-        if(projectName && kind) queryPath += `&kind=${kind}`;
-        if(projectName && page) queryPath += `&page=${page}`;
-        if(queryPath !== '/datastore_viewer/?') history.push(queryPath);
+        if(history.location.pathname === '/datastore_viewer/') {
+            let queryPath = '/datastore_viewer/?';
+            if (projectName) queryPath += `projectName=${projectName}`;
+            if (projectName && kind) queryPath += `&kind=${kind}`;
+            if (projectName && page) queryPath += `&page=${page}`;
+            if (queryPath !== '/datastore_viewer/?') history.push(queryPath);
+        }
     }, [kind, page]);
 
     React.useEffect(() => {
-         setKind('');
-         setPage(0);
-         history.push(`/datastore_viewer/?projectName=${projectName}`);
+        if(history.location.pathname === '/datastore_viewer/') {
+            setKind('');
+            setPage(0);
+            history.push(`/datastore_viewer/?projectName=${projectName}`);
+        }
     }, [projectName]);
 
     return (

--- a/webapp/src/presentation/locales/en.json
+++ b/webapp/src/presentation/locales/en.json
@@ -43,7 +43,7 @@
       "PropertyItem": {
         "value": "Value",
         "empty": "Empty",
-        "subTitle": "Indexed",
+        "indexed": "Indexed",
         "name": "Name",
         "type": "Type",
         "registIndex": "Index This Property",
@@ -54,6 +54,7 @@
           "float": "Float",
           "bool": "Boolean",
           "key": "Key",
+          "unknown": "Unknown",
           "null": "Null"
         },
         "boolItem": {

--- a/webapp/src/presentation/locales/ja.json
+++ b/webapp/src/presentation/locales/ja.json
@@ -43,7 +43,7 @@
       "PropertyItem": {
         "value": "値",
         "empty": "空白",
-        "subTitle": "インデックス登録",
+        "indexed": "インデックス登録",
         "name": "名前",
         "type": "タイプ",
         "registIndex": "このプロパティをインデックス登録する",
@@ -54,6 +54,7 @@
           "float": "浮動小数点数",
           "bool": "ブール値",
           "key": "Key",
+          "unknown": "Unknown",
           "null": "Null"
         },
         "boolItem": {

--- a/webapp/src/presentation/views/EntityEdit/EntityEdit.tsx
+++ b/webapp/src/presentation/views/EntityEdit/EntityEdit.tsx
@@ -26,12 +26,11 @@ const useStyles = makeStyles((theme: Theme) =>
 );
 
 interface Props {
-    projectName: any;
     lang: string;
 }
 
 export default function EntityEdit(props: Props) {
-    let { kind, urlSafeKey } = useParams();
+    let { kind, urlSafeKey, projectName } = useParams();
     const [entity, setEntity] = React.useState<EntityObject>();
     const [t, i18n] = useTranslation();
 
@@ -40,8 +39,8 @@ export default function EntityEdit(props: Props) {
     }, [props.lang, i18n]);
 
     const updateEntity = () => {
-        if(kind && urlSafeKey) {
-            getEntity(props.projectName, kind, urlSafeKey)
+        if(kind && urlSafeKey && projectName) {
+            getEntity(projectName, kind, urlSafeKey)
                 .then(res => setEntity(res));
         }
     };

--- a/webapp/src/presentation/views/EntityEdit/components/MenuBar/MenuBar.tsx
+++ b/webapp/src/presentation/views/EntityEdit/components/MenuBar/MenuBar.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { Link } from "react-router-dom";
+import { useHistory } from "react-router-dom";
 import Button from '@material-ui/core/Button';
 import IconButton from '@material-ui/core/IconButton';
 import ArrowBackIcon from '@material-ui/icons/ArrowBack';
@@ -41,6 +41,7 @@ interface Props {
 }
 
 export default function MenuBar(props: Props) {
+    const history = useHistory();
     const classes = useStyles();
     const [t, i18n] = useTranslation();
 
@@ -54,11 +55,9 @@ export default function MenuBar(props: Props) {
 
     return (
         <div className={classes.root}>
-            <Link to={'/datastore_viewer'}>
-                <IconButton aria-label="back" className={classes.iconButton}>
-                    <ArrowBackIcon fontSize="inherit" />
-                </IconButton>
-            </Link>
+            <IconButton aria-label="back" className={classes.iconButton} onClick={history.goBack}>
+                <ArrowBackIcon fontSize="inherit"/>
+            </IconButton>
             <div className={classes.title}>{t('EntityEdit.MenuBar.title')}</div>
             <Button startIcon={<RefreshIcon/>} onClick={handleClickRefreashEntity} className={classes.button}>
                 {t('EntityEdit.MenuBar.refresh')}

--- a/webapp/src/presentation/views/EntityEdit/components/PropertyMenu/PropertyMenu.tsx
+++ b/webapp/src/presentation/views/EntityEdit/components/PropertyMenu/PropertyMenu.tsx
@@ -19,15 +19,13 @@ import Card from '@material-ui/core/Card';
 import Button from '@material-ui/core/Button';
 import DeleteIcon from '@material-ui/icons/Delete';
 import IconButton from "@material-ui/core/IconButton";
+import {Typography} from "@material-ui/core";
 
 
 const useMenuItemStyles = makeStyles((theme: Theme) =>
     createStyles({
         root: {
             outline: 'solid 1px lightgrey',
-        },
-        itemName: {
-            fontSize: 14,
         },
         inputFont: {
             fontSize: 13,
@@ -38,7 +36,7 @@ const useMenuItemStyles = makeStyles((theme: Theme) =>
         },
         textField: {
             width:'100%',
-}       ,
+        },
         select: {
             height: 30,
             paddingTop: 0,
@@ -123,6 +121,14 @@ const PropertyItem: React.FC<PropertyProps> = props => {
             }
         } else {
             return `${name}: ${value}`;
+        }
+    };
+
+    const checkIndexed = () => {
+        if(checkState) {
+            return t('EntityEdit.PropertyMenu.PropertyItem.indexed');
+        }else {
+            return null;
         }
     };
 
@@ -219,6 +225,20 @@ const PropertyItem: React.FC<PropertyProps> = props => {
                         label={t('EntityEdit.PropertyMenu.PropertyItem.value')}
                         variant="outlined" /> );
 
+            case 'Unknown':
+                return (
+                    <TextField
+                        required
+                        value={value}
+                        onChange={handleFormValueChange}
+                        size={'small'}
+                        multiline={true}
+                        InputLabelProps={{ shrink: true }}
+                        InputProps={{ classes: { input: classes.inputFont } }}
+                        className={classes.textField}
+                        label={t('EntityEdit.PropertyMenu.PropertyItem.value')}
+                        variant="outlined" /> );
+
             case 'Null':
                 return;
         }
@@ -228,18 +248,34 @@ const PropertyItem: React.FC<PropertyProps> = props => {
         <div className={classes.root}>
             <ListItem button onClick={handleClick}>
                 <ListItemText
-                    classes={{
-                        primary: classes.itemName,
-                        secondary: classes.inputFont
-                    }}
-                    primary={ makeTitle() }
-                    secondary={t('EntityEdit.PropertyMenu.PropertyItem.subTitle')}
+                    disableTypography
+                    primary={
+                        <Typography
+                            style={{
+                                fontSize: 14,
+                                whiteSpace: 'nowrap',
+                                overflow: 'hidden',
+                                textOverflow:'ellipsis',
+                            }}
+                        >
+                            { makeTitle() }
+                        </Typography>
+                    }
+                    secondary={
+                        <Typography
+                            style={{
+                                color: 'grey'
+                                , fontSize: 13 }}
+                        >
+                            { checkIndexed() }
+                        </Typography>
+                    }
                 />
-                {open &&
-                    <IconButton onClick={handleDeleteButton} aria-label="delete">
-                        <DeleteIcon fontSize="inherit" />
-                    </IconButton>
-                }
+                {/*{open &&*/}
+                {/*    <IconButton onClick={handleDeleteButton} aria-label="delete">*/}
+                {/*        <DeleteIcon fontSize="inherit" />*/}
+                {/*    </IconButton>*/}
+                {/*}*/}
                 {open ? <ExpandLess /> : <ExpandMore />}
             </ListItem>
             <Collapse in={open} timeout="auto" unmountOnExit>
@@ -276,6 +312,7 @@ const PropertyItem: React.FC<PropertyProps> = props => {
                                     <MenuItem className={classes.inputFont} value={'Float'}>{t('EntityEdit.PropertyMenu.PropertyItem.listItem.float')}</MenuItem>
                                     <MenuItem className={classes.inputFont} value={'Boolean'}>{t('EntityEdit.PropertyMenu.PropertyItem.listItem.bool')}</MenuItem>
                                     <MenuItem className={classes.inputFont} value={'Key'}>{t('EntityEdit.PropertyMenu.PropertyItem.listItem.key')}</MenuItem>
+                                    <MenuItem className={classes.inputFont} value={'Unknown'}>{t('EntityEdit.PropertyMenu.PropertyItem.listItem.unknown')}</MenuItem>
                                     <MenuItem className={classes.inputFont} value={'Null'}>{t('EntityEdit.PropertyMenu.PropertyItem.listItem.null')}</MenuItem>
                                 </TextField>
                             </ListItem>
@@ -322,7 +359,7 @@ const useStyles = makeStyles((theme: Theme) =>
         list: {
             margin: theme.spacing(2),
             width: '100%',
-            maxWidth: 360,
+            maxWidth: 450,
             backgroundColor: theme.palette.background.paper,
         },
         title: {

--- a/webapp/src/presentation/views/EntityEdit/components/PropertyMenu/PropertyMenu.tsx
+++ b/webapp/src/presentation/views/EntityEdit/components/PropertyMenu/PropertyMenu.tsx
@@ -114,8 +114,8 @@ const PropertyItem: React.FC<PropertyProps> = props => {
         if(!name) {
             return t('EntityEdit.PropertyMenu.PropertyItem.empty');
         } else if(!value) {
-            if(type === "Null") {
-                return `${name}`;
+            if(type === "Null" || type === "Boolean") {
+                return `${name}: ${value}`;
             }else {
                 return `${name}: ${t('EntityEdit.PropertyMenu.PropertyItem.empty')}`;
             }

--- a/webapp/src/presentation/views/EntityList/EntityList.tsx
+++ b/webapp/src/presentation/views/EntityList/EntityList.tsx
@@ -73,6 +73,7 @@ export default function EntityList(props: Props) {
                         rowsPerPage={rowsPerPage}
                         setPage={setPage}
                         lang={props.lang}
+                        projectName={props.projectName}
                     /> :
                     <NotFound
                         lang={props.lang}

--- a/webapp/src/presentation/views/EntityList/components/EntityListBody/EntityListBody.tsx
+++ b/webapp/src/presentation/views/EntityList/components/EntityListBody/EntityListBody.tsx
@@ -217,6 +217,7 @@ const useStyles = makeStyles((theme: Theme) =>
 interface Props {
   entityCollection: EntityCollection | undefined;
   lang: string;
+  projectName: string;
   kindObj: KindResult | undefined;
   page: number;
   rowsPerPage: number;
@@ -230,6 +231,7 @@ export default function EnhancedTable(props: Props) {
   const [selected, setSelected] = React.useState<string[]>([]);
   const rowsPerPage = props.rowsPerPage;
   const page = props.page;
+  const projectName = props.projectName;
   const entityCollection = props.entityCollection;
   const setPage = props.setPage;
   const rows = convertData(entityCollection?.entities || []);
@@ -355,7 +357,7 @@ export default function EnhancedTable(props: Props) {
                         />
                       </TableCell>
                       <TableCell component="th" id={labelId} scope="row" padding="none">
-                        <NavLink className={classes.link} to={`/datastore_viewer/edit/update/${row.kind}/${row.urlSafeKey}`} >{row.name_id}</NavLink>
+                        <NavLink className={classes.link} to={`/datastore_viewer/edit/update/${projectName}/${row.kind}/${row.urlSafeKey}`} >{row.name_id}</NavLink>
                       </TableCell>
                       {row.parent && <TableCell className={classes.cell} key={row.parent} align="left">{ row.parent }</TableCell>}
                       {

--- a/webapp/src/presentation/views/NewEntityEdit/components/MenuBar/MenuBar.tsx
+++ b/webapp/src/presentation/views/NewEntityEdit/components/MenuBar/MenuBar.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { Link } from "react-router-dom";
+import { useHistory } from "react-router-dom";
 import IconButton from '@material-ui/core/IconButton';
 import ArrowBackIcon from '@material-ui/icons/ArrowBack';
 import {createStyles, makeStyles, Theme} from "@material-ui/core/styles";
@@ -31,6 +31,7 @@ interface Props {
 
 export default function MenuBar(props: Props) {
     const classes = useStyles();
+    const history = useHistory();
     const [t, i18n] = useTranslation();
 
     React.useEffect(() => {
@@ -39,11 +40,9 @@ export default function MenuBar(props: Props) {
 
     return (
         <div className={classes.root}>
-            <Link to={'/'}>
-                <IconButton aria-label="back" className={classes.iconButton}>
-                    <ArrowBackIcon fontSize="inherit" />
-                </IconButton>
-            </Link>
+            <IconButton aria-label="back" className={classes.iconButton} onClick={history.goBack}>
+                <ArrowBackIcon fontSize="inherit" />
+            </IconButton>
             <div className={classes.title}>{t('NewEntityEdit.MenuBar.title')}</div>
         </div>
     )


### PR DESCRIPTION
* PropertyTitle が長い場合は省略する
* PropertyList の幅を 450px に拡大
* Entityの詳細画面でリロードしてもページを保持
* Property が index されているときのみ Indexed を表示
* BooleanProperty のときは Title に True/False を表示
* NullPropertyのときは Title にNull と表示
* PropertyList の表示を UnknownProperty に対応