### PR TITLE
エンティティ一覧のソート機能を追加

### DIFF
--- a/datastore_viewer/infrastructure/__init__.py
+++ b/datastore_viewer/infrastructure/__init__.py
@@ -113,9 +113,12 @@ class DatastoreViewerRepository:
 
         return properties_by_kind
 
-    def fetch_entities(self, kind: str, per_page: int = 25, page_number: int = 1) -> Tuple[List[datastore.Entity], int]:
+    def fetch_entities(self, kind: str, per_page: int = 25, page_number: int = 1, orderBy: str = "") -> Tuple[List[datastore.Entity], int]:
         offset = per_page * (page_number - 1)
         query: datastore.Query = self.datastore_client.query(kind=kind)
+
+        if orderBy != "":
+            query.order = orderBy
 
         entities = []
         for entity in query.fetch(limit=per_page, offset=offset):

--- a/datastore_viewer/presentation/ui/api/__init__.py
+++ b/datastore_viewer/presentation/ui/api/__init__.py
@@ -36,6 +36,7 @@ class ProjectAPIView(flask.views.MethodView):
     def get(self, project_name: str, kind: str):
         per_page = int(flask.request.args.get('perPage', '25'))
         page_number = int(flask.request.args.get('page', '1'))
+        order = flask.request.args.get('order', '')
 
         encoder = DataStoreEntityJSONEncoder()
         repository = DatastoreViewerRepository(project_name=project_name)
@@ -48,6 +49,7 @@ class ProjectAPIView(flask.views.MethodView):
             kind=current_kind,
             per_page=per_page,
             page_number=page_number,
+            orderBy=order,
         )
 
         entities_array = []

--- a/webapp/src/api-types/request.ts
+++ b/webapp/src/api-types/request.ts
@@ -5,6 +5,7 @@ export namespace Request {
       kind: string;
       pageNumber?: number;
       rowsPerPage?: number;
+      order?: string;
     }
 
     export interface Fetch {

--- a/webapp/src/infra/entity/entityClient.ts
+++ b/webapp/src/infra/entity/entityClient.ts
@@ -18,6 +18,9 @@ export async function fetchEntities(
   } else {
     urlParams.append('perPage', `${defaultRowsPerPage}`);
   }
+  if (params.order) {
+    urlParams.append('order', params.order);
+  }
 
   const url = `/datastore_viewer/api/projects/${params.projectName}/kinds/${
     params.kind

--- a/webapp/src/pages/EntityList/EntityList.tsx
+++ b/webapp/src/pages/EntityList/EntityList.tsx
@@ -28,6 +28,7 @@ export const EntityList: React.FunctionComponent<Props> = ({
   const [kinds, setKinds] = React.useState<Domain.KindResult[] | undefined>();
   const [kindObj, setKindObj] = React.useState<Domain.KindResult>();
   const [page, setPage] = React.useState<number>(currentPage);
+  const [order, setOrder] = React.useState<string>('');
   const [selected, setSelected] = React.useState<string[]>([]);
   const [ableDeleteButton, setAbleDeleteButton] = React.useState<boolean>(
     false,
@@ -51,22 +52,27 @@ export const EntityList: React.FunctionComponent<Props> = ({
     }
   }, [selected]);
 
-  const updateEntities = React.useCallback(() => {
-    if (kindObj) {
-      fetchEntities({
-        projectName,
-        kind: kindObj.kind,
-        pageNumber: page,
-        rowsPerPage,
-      }).then((collection) => {
-        const maxPage = Math.floor(collection.totalCount / rowsPerPage);
-        if (maxPage < page) setPage(maxPage);
-        console.log('updateEntities', collection);
-        setEntities(collection);
-      });
-    }
-    setCurrentPage(page);
-  }, [kindObj, projectName, page]);
+  const updateEntities = React.useCallback(
+    (isKindChanged?: boolean) => {
+      if (kindObj) {
+        const selectedOrder = isKindChanged ? '' : order;
+        fetchEntities({
+          projectName,
+          kind: kindObj.kind,
+          pageNumber: page,
+          rowsPerPage,
+          order: selectedOrder,
+        }).then((collection) => {
+          const maxPage = Math.floor(collection.totalCount / rowsPerPage);
+          if (maxPage < page) setPage(maxPage);
+          console.log('updateEntities', collection);
+          setEntities(collection);
+        });
+      }
+      setCurrentPage(page);
+    },
+    [kindObj, projectName, page, order],
+  );
 
   const removeEntities = () => {
     deleteEntities({
@@ -79,8 +85,12 @@ export const EntityList: React.FunctionComponent<Props> = ({
   };
 
   React.useEffect(() => {
-    updateEntities();
-  }, [kindObj, updateEntities]);
+    updateEntities(true);
+  }, [kindObj]);
+
+  React.useEffect(() => {
+    updateEntities(false);
+  }, [order]);
 
   React.useEffect(() => {
     console.log('effect watch', entityCollection);
@@ -110,6 +120,7 @@ export const EntityList: React.FunctionComponent<Props> = ({
           rowsPerPage={rowsPerPage}
           setPage={setPage}
           setSelectedItems={setSelected}
+          setSortOrder={setOrder}
           lang={lang}
           projectName={projectName}
         />

--- a/webapp/src/pages/EntityList/internal/EntityListBody/EntityListBody.tsx
+++ b/webapp/src/pages/EntityList/internal/EntityListBody/EntityListBody.tsx
@@ -157,18 +157,17 @@ const EnhancedTableHead: React.FunctionComponent<EnhancedTableProps> = ({
               padding="default"
               sortDirection={orderBy === headCell.id ? order : false}
               style={{ fontWeight: 'bolder' }}>
-              {/* <TableSortLabel */}
-              {/*  active={orderBy === headCell.id} */}
-              {/*  direction={orderBy === headCell.id ? order : 'asc'} */}
-              {/*  onClick={createSortHandler(headCell.id)} */}
-              {/* > */}
-              {headCell.label}
-              {/*  {orderBy === headCell.id ? ( */}
-              {/*    <span className={classes.visuallyHidden}> */}
-              {/*      {order === 'desc' ? 'sorted descending' : 'sorted ascending'} */}
-              {/*    </span> */}
-              {/*  ) : null} */}
-              {/* </TableSortLabel> */}
+              <TableSortLabel
+                active={orderBy === headCell.id}
+                direction="asc"
+                onClick={createSortHandler(headCell.id)}>
+                {headCell.label}
+                {orderBy === headCell.id && (
+                  <span className={classes.visuallyHidden}>
+                    sorted ascending
+                  </span>
+                )}
+              </TableSortLabel>
             </TableCell>
           );
         })}
@@ -181,18 +180,19 @@ const EnhancedTableHead: React.FunctionComponent<EnhancedTableProps> = ({
                 padding="default"
                 sortDirection={orderBy === headCell.id ? order : false}
                 style={{ fontWeight: 'bolder' }}>
-                {/* <TableSortLabel */}
-                {/*  active={orderBy === headCell.id} */}
-                {/*  direction={orderBy === headCell.id ? order : 'asc'} */}
-                {/*  onClick={createSortHandler(headCell.id)} */}
-                {/* > */}
-                {headCell.label}
-                {/*  {orderBy === headCell.id ? ( */}
-                {/*    <span className={classes.visuallyHidden}> */}
-                {/*      {order === 'desc' ? 'sorted descending' : 'sorted ascending'} */}
-                {/*    </span> */}
-                {/*  ) : null} */}
-                {/* </TableSortLabel> */}
+                <TableSortLabel
+                  active={orderBy === headCell.id}
+                  direction={orderBy === headCell.id ? order : 'asc'}
+                  onClick={createSortHandler(headCell.id)}>
+                  {headCell.label}
+                  {orderBy === headCell.id && (
+                    <span className={classes.visuallyHidden}>
+                      {order === 'desc'
+                        ? 'sorted descending'
+                        : 'sorted ascending'}
+                    </span>
+                  )}
+                </TableSortLabel>
               </TableCell>
             );
           }
@@ -203,18 +203,19 @@ const EnhancedTableHead: React.FunctionComponent<EnhancedTableProps> = ({
               padding="default"
               sortDirection={orderBy === headCell.id ? order : false}
               style={{ fontWeight: 'bolder', color: 'grey' }}>
-              {/* <TableSortLabel */}
-              {/*  active={orderBy === headCell.id} */}
-              {/*  direction={orderBy === headCell.id ? order : 'asc'} */}
-              {/*  onClick={createSortHandler(headCell.id)} */}
-              {/* > */}
-              {headCell.label}
-              {/*  {orderBy === headCell.id ? ( */}
-              {/*    <span className={classes.visuallyHidden}> */}
-              {/*      {order === 'desc' ? 'sorted descending' : 'sorted ascending'} */}
-              {/*    </span> */}
-              {/*  ) : null} */}
-              {/* </TableSortLabel> */}
+              <TableSortLabel
+                active={orderBy === headCell.id}
+                direction={orderBy === headCell.id ? order : 'asc'}
+                onClick={createSortHandler(headCell.id)}>
+                {headCell.label}
+                {orderBy === headCell.id && (
+                  <span className={classes.visuallyHidden}>
+                    {order === 'desc'
+                      ? 'sorted descending'
+                      : 'sorted ascending'}
+                  </span>
+                )}
+              </TableSortLabel>
             </TableCell>
           );
         })}
@@ -232,6 +233,7 @@ type Props = {
   rowsPerPage: number;
   setPage: (pageNumber: number) => void;
   setSelectedItems: (selected: string[]) => void;
+  setSortOrder: (property: string) => void;
 };
 
 export const EntityListBody: React.FunctionComponent<Props> = ({
@@ -243,6 +245,7 @@ export const EntityListBody: React.FunctionComponent<Props> = ({
   rowsPerPage,
   setPage,
   setSelectedItems,
+  setSortOrder,
 }) => {
   const classes = useStyles();
   const [order, setOrder] = React.useState<Order>('asc');
@@ -263,6 +266,16 @@ export const EntityListBody: React.FunctionComponent<Props> = ({
   React.useEffect(() => {
     setSelectedItems(selected);
   }, [selected]);
+
+  React.useEffect(() => {
+    if (orderBy !== 'id') {
+      let choosedOrder = orderBy;
+      if (order === 'desc') choosedOrder = `-${orderBy}`;
+      setSortOrder(choosedOrder);
+    } else {
+      setSortOrder('');
+    }
+  }, [order, orderBy]);
 
   const headCellIds: HeadCell[] = [
     {
@@ -288,27 +301,6 @@ export const EntityListBody: React.FunctionComponent<Props> = ({
       });
     });
   }
-
-  const stableSort = (orders: Order) => {
-    if (orders === 'asc') {
-      if (orderBy !== 'name_id') {
-        return _.sortBy(rows, (row) => {
-          return row.properties[orderBy];
-        });
-      }
-      return _.sortBy(rows, (row) => {
-        return row[orderBy];
-      });
-    }
-    if (orderBy !== 'name_id') {
-      return _.sortBy(rows, (row) => {
-        return row.properties[orderBy];
-      }).reverse();
-    }
-    return _.sortBy(rows, (row) => {
-      return row[orderBy];
-    }).reverse();
-  };
 
   const handleRequestSort = (
     event: React.MouseEvent<unknown>,
@@ -375,68 +367,66 @@ export const EntityListBody: React.FunctionComponent<Props> = ({
               headCellProperties={headCellProperties}
             />
             <TableBody>
-              {stableSort(order)
-                // .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
-                .map((row, index) => {
-                  const isItemSelected = isSelected(row.urlSafeKey);
-                  const labelId = `enhanced-table-checkbox-${index}`;
+              {rows.map((row, index) => {
+                const isItemSelected = isSelected(row.urlSafeKey);
+                const labelId = `enhanced-table-checkbox-${index}`;
 
-                  return (
-                    <TableRow
-                      hover
-                      onClick={(event) => handleClick(event, row.urlSafeKey)}
-                      role="checkbox"
-                      aria-checked={isItemSelected}
-                      tabIndex={-1}
-                      key={row.urlSafeKey}
-                      selected={isItemSelected}>
-                      <TableCell padding="checkbox">
-                        <Checkbox
-                          checked={isItemSelected}
-                          inputProps={{ 'aria-labelledby': labelId }}
-                        />
-                      </TableCell>
+                return (
+                  <TableRow
+                    hover
+                    onClick={(event) => handleClick(event, row.urlSafeKey)}
+                    role="checkbox"
+                    aria-checked={isItemSelected}
+                    tabIndex={-1}
+                    key={row.urlSafeKey}
+                    selected={isItemSelected}>
+                    <TableCell padding="checkbox">
+                      <Checkbox
+                        checked={isItemSelected}
+                        inputProps={{ 'aria-labelledby': labelId }}
+                      />
+                    </TableCell>
+                    <TableCell
+                      component="th"
+                      id={labelId}
+                      scope="row"
+                      padding="none">
+                      <NavLink
+                        className={classes.link}
+                        to={`/datastore_viewer/edit/update/${projectName}/${row.kind}/${row.urlSafeKey}`}>
+                        {row.name_id}
+                      </NavLink>
+                    </TableCell>
+                    {row.parent && (
                       <TableCell
-                        component="th"
-                        id={labelId}
-                        scope="row"
-                        padding="none">
-                        <NavLink
-                          className={classes.link}
-                          to={`/datastore_viewer/edit/update/${projectName}/${row.kind}/${row.urlSafeKey}`}>
-                          {row.name_id}
-                        </NavLink>
+                        className={classes.cell}
+                        key={row.parent}
+                        align="left">
+                        {row.parent}
                       </TableCell>
-                      {row.parent && (
-                        <TableCell
-                          className={classes.cell}
-                          key={row.parent}
-                          align="left">
-                          {row.parent}
-                        </TableCell>
-                      )}
-                      {headCellProperties.map((property) => {
-                        if (row.properties[property.id]) {
-                          return (
-                            <TableCell
-                              className={classes.cell}
-                              key={property.id}
-                              align="left">
-                              {row.properties[property.id].value}
-                            </TableCell>
-                          );
-                        }
+                    )}
+                    {headCellProperties.map((property) => {
+                      if (row.properties[property.id]) {
                         return (
                           <TableCell
                             className={classes.cell}
                             key={property.id}
-                            align="left"
-                          />
+                            align="left">
+                            {row.properties[property.id].value}
+                          </TableCell>
                         );
-                      })}
-                    </TableRow>
-                  );
-                })}
+                      }
+                      return (
+                        <TableCell
+                          className={classes.cell}
+                          key={property.id}
+                          align="left"
+                        />
+                      );
+                    })}
+                  </TableRow>
+                );
+              })}
             </TableBody>
           </Table>
         </TableContainer>

--- a/webapp/src/pages/EntityList/internal/EntityListBody/EntityListBody.tsx
+++ b/webapp/src/pages/EntityList/internal/EntityListBody/EntityListBody.tsx
@@ -203,19 +203,7 @@ const EnhancedTableHead: React.FunctionComponent<EnhancedTableProps> = ({
               padding="default"
               sortDirection={orderBy === headCell.id ? order : false}
               style={{ fontWeight: 'bolder', color: 'grey' }}>
-              <TableSortLabel
-                active={orderBy === headCell.id}
-                direction={orderBy === headCell.id ? order : 'asc'}
-                onClick={createSortHandler(headCell.id)}>
-                {headCell.label}
-                {orderBy === headCell.id && (
-                  <span className={classes.visuallyHidden}>
-                    {order === 'desc'
-                      ? 'sorted descending'
-                      : 'sorted ascending'}
-                  </span>
-                )}
-              </TableSortLabel>
+              {headCell.label}
             </TableCell>
           );
         })}


### PR DESCRIPTION
* エンティティ一覧をソートできるように変更
* ページングをしている関係でフロントのもつエンティティのソートではなく、サーバー側でクエリを叩いてソートする
* Datastoreの仕様上id/nameはソートできない(昇順でしか取得できない)のでid/nameは昇順のみのソート(という名目のただの再fetch)で実装